### PR TITLE
feat: Improve error handling

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -107,20 +107,26 @@ func RunCommand(cmd *cobra.Command, args []string) {
 	client, err := kubernetes.NewClient()
 
 	// Process PipelineRun resources in the background
-	// TODO: Errors for watcher must be shown inside the watcher as this is a goroutine
+	// Hey!, errors for watcher must be shown inside the watcher as this is a goroutine
 	go func() {
-		err := kubernetes.WatchPipelineRuns(&globals.ExecContext.Context, client)
-		if err != nil {
-
+		// Following loop grants re-launching the goroutine when it fails
+		for {
+			err := kubernetes.WatchPipelineRuns(&globals.ExecContext.Context, client)
+			if err != nil {
+				globals.ExecContext.Logger.Errorf("error on PipelineRun objects watcher: %s", err)
+			}
 		}
 	}()
 
 	// Process TaskRun resources in the background
-	// TODO: Errors for watcher must be shown inside the watcher as this is a goroutine
+	// Hey, errors for watcher must be shown inside the watcher as this is a goroutine
 	go func() {
-		err := kubernetes.WatchTaskRuns(&globals.ExecContext.Context, client)
-		if err != nil {
-
+		// Following loop grants re-launching the goroutine when it fails
+		for {
+			err := kubernetes.WatchTaskRuns(&globals.ExecContext.Context, client)
+			if err != nil {
+				globals.ExecContext.Logger.Errorf("error on TaskRun objects watcher: %s", err)
+			}
 		}
 	}()
 

--- a/internal/kubernetes/utils.go
+++ b/internal/kubernetes/utils.go
@@ -36,8 +36,13 @@ func GetObjectLabels(obj *runtime.Object) (labelsMap map[string]string, err erro
 	}
 
 	// Read labels from event's resource
-	objectMetadata := object["metadata"]
-	objectLabelsOriginal := objectMetadata.(map[string]interface{})["labels"]
+	objectMetadata := object["metadata"].(map[string]interface{})
+
+	// If there is no label, just quit
+	objectLabelsOriginal := objectMetadata["labels"]
+	if reflect.TypeOf(objectLabelsOriginal) == nil {
+		return labelsMap, nil
+	}
 	objectLabels := objectLabelsOriginal.(map[string]interface{})
 
 	labelsMap = make(map[string]string)


### PR DESCRIPTION
**Description:** 
* Run objects watchers are restarted when they return an error
* Manage most errors inside goroutines instead of throwing them (treat them as completely separated processes). 
* In watching process, when extracting information from malformed Run objects ends with missing data, default behavior is to log and skip the object
* Error messages templates are now constants on top
* GVR definition for Taskrun and Pipelinerun resources are now defined as variable 